### PR TITLE
Removed prefixes from API URLs, and moved versioning to Accept header

### DIFF
--- a/join-protocol.md
+++ b/join-protocol.md
@@ -9,7 +9,7 @@ It is not mandatory for **A** to automatically also accept **B**’s requests, t
 **1.a.** When requesting access to **B**, the administrators of **A** must send to the administrators of **B**:
 * a human readable **name** identifying **A**, to be presented to data owners on **B** when a search submitted by **A** matches patients in **B** and **B** wants to notify the data owners of a match (optional behavior that can be implemented by **B**)
 * an **authentication token** to be used by **B** in its requests to **A**, if any, to authenticate **B** to **A**, for example when sending back asynchronous match results; if the search agreement is mutual, this is also the token that **B** will use when submitting match requests to **A**
-* a **base URL** to be used for requests, including scheme (`https://`), domain, eventual port, and path prefix (trailing `/` is optional); **B** will append `/mmapi/v1/matchResults` to this path when sending back asynchronous results, or, if **B** is to also be allowed to send queries to **A**, `/mmapi/v1/match`
+* a **base URL** to be used for requests, including scheme (`https://`), domain, eventual port, and path prefix (trailing `/` is optional); **B** will append `/matchResults` to this path when sending back asynchronous results, or, if **B** is to also be allowed to send queries to **A**, `/match`
 * the preferred **response type** expected by **A**; if **B** does not support this type, then the two parties should negotiate what works best for them
   * the `responseType` is defined in the search response JSON  format, with the possible values of `"inline"`|`"asynchronous"`|`"email"`
 
@@ -32,7 +32,7 @@ gpg --decrypt --output key key.gpg
 **1.b.** Upon acceptance of **A** as a trusted source of queries, the administrators of **B** must respond with:
 * a suggested human readable **name** and **description** identifying **B**, to be presented to users of **A** as a possible remote site to search; **A** could ignore these and use their preferred name and description, but for consistency across systems **B**’s preference should be used
 * an **authentication token** that must be used by **A** in the search requests
-* a **base URL** to be used for requests, including scheme (`https://`), hostname, eventual port, and path prefix (trailing `/` is optional); **A** will append `/mmapi/v1/match` to this path when sending queries
+* a **base URL** to be used for requests, including scheme (`https://`), hostname, eventual port, and path prefix (trailing `/` is optional); **A** will append `/match` to this path when sending queries
 
 **For data security, HTTPS is mandatory, with a valid, globally acceptable certificate!**
 
@@ -54,9 +54,9 @@ Since authentication tokens are the only means of identifying a site, this token
 
 **3.** Every HTTP request that **A** submits to **B** must contain the token that **B** told **A** to use in HTTP header called 'X-Auth-Token'. For example:
 
-    https://phenomecentral.org/rest/remoteMatcher/mmapi/v1/match
+    https://phenomecentral.org/rest/remoteMatcher/match
     
-    POST /rest/remoteMatcher/mmapi/v1/match HTTP/1.1
+    POST /rest/remoteMatcher/match HTTP/1.1
 	Host: phenomecentral.org
 	Accept: application/json
 	Content-Type: application/json; charset=UTF-8
@@ -64,7 +64,7 @@ Since authentication tokens are the only means of identifying a site, this token
 
 In this case:
 * `https://phenomecentral.org/rest/remoteMatcher` is the base URL
-* `/mmapi/v1/match` is the API method for submitting queries
+* `/match` is the API method for submitting queries
 * `854a439d278df4283bf5498ab020336cdc416a7d` is the authentication token that **B** told **A** to use in all match requests
 * `X-Auth-Token: 854a439d278df4283bf5498ab020336cdc416a7d` would be in the Request Header sent to **B**
 

--- a/search-api.md
+++ b/search-api.md
@@ -1,24 +1,50 @@
 # OVERVIEW
 
 **Submit patient matching request:**
-`HTTP POST` to remote server: `<base_remote_url>/mmapi/v1/match`
-For example: `https://yourmatchmaker.org/mmapi/v1/match`
+`HTTP POST` to remote server: `<base_remote_url>/match`
+For example: `https://yourmatchmaker.org/match`
 
 **Receive asynchronous response:**
-`HTTP POST` from remote server to: `<base_origin_url>/mmapi/v1/matchResults`
-For example: `https://mymatchmaker.org/mmapi/v1/matchResults`
+`HTTP POST` from remote server to: `<base_origin_url>/matchResults`
+For example: `https://mymatchmaker.org/matchResults`
 
 **Update previous request:**
-`HTTP PUT` to remote server: `<base_remote_url>/mmapi/v1/match/<queryID>`
-For example: `https://yourmatchmaker.org/mmapi/v1/match/a32fa90vd`
+`HTTP PUT` to remote server: `<base_remote_url>/match/<queryID>`
+For example: `https://yourmatchmaker.org/match/a32fa90vd`
 
 **Delete previous request:**
-`HTTP DELETE` to remote server: `<base_remote_url>/mmapi/v1/match/<queryID>`
-For example: `https://yourmatchmaker.org/mmapi/v1/match/a32fa90vd`
+`HTTP DELETE` to remote server: `<base_remote_url>/match/<queryID>`
+For example: `https://yourmatchmaker.org/match/a32fa90vd`
+
+
+## Versioning
+
+A particular API version can be specified using the HTTP `Accept` header.
+
+`Accept: application/vnd.ga4gh.matchmaker[.version]+json`
+
+Where version takes the form `vX.Y`. For example:
+
+`Accept: application/vnd.ga4gh.matchmaker.v0.1+json`
+
+If no version is specified, the remote server should respond in whatever is the latest version. The remote server should always provide the API version in the `Content-Type` header of every response:
+
+`Content-Type: application/vnd.ga4gh.matchmaker.v0.7+json`
+
+After receiving a request, the remote server can respond in one of two ways:
+  * If a compatible version (`vX.Z` where `Z>=Y`) is supported by the remote server, it should provide a response using this version.
+  * If no appropriate version is supported by the remote server, it should respond with `Not Acceptable (406)`, containing a JSON body with a description of the error. All responses, including this one, should contain a `Content-Type` header with the latest API version supported by the server. This will enable the user to re-submit the request using this version of the API.
+
+```json
+{
+  "message" : "unsupported version number"
+}
+```
+
 
 ## Search Request
 
-`HTTP POST` request to `<base_remote_url>/mmapi/v1/match`, with an `application/json` body with the following format:
+`HTTP POST` request to `<base_remote_url>/match`, with an `application/json` body with the following format:
 
 ### Example
 
@@ -169,7 +195,7 @@ For example: `https://yourmatchmaker.org/mmapi/v1/match/a32fa90vd`
 * This should list either *candidate genes*, using the `gene` field with optionally other more specific fields, or precise *genomic variants*, specifying the assembly, the location (`referenceName`, `start`, `end`), and the reference and alternate bases
 
 ## Search Results Response
-Either a synchronous `application/json` response to a `/match` request, an asynchronous `application/json` `HTTP POST` request to `<base_origin_url>/mmapi/v1/matchResults`, or a human-readable email sent to the user’s email address.
+Either a synchronous `application/json` response to a `/match` request, an asynchronous `application/json` `HTTP POST` request to `<base_origin_url>/matchResults`, or a human-readable email sent to the user’s email address.
 
 The response to the search request looks like:
 
@@ -236,7 +262,7 @@ The response to the search request looks like:
 The format of email responses is not restricted, and is left up to each site to implement in a user-friendly way.
 
 ## Search Request Update
-`HTTP PUT` request to `<base_remote_url>/mmapi/v1/match/<queryID>`, with an `application/json` body with the same format as a search request:
+`HTTP PUT` request to `<base_remote_url>/match/<queryID>`, with an `application/json` body with the same format as a search request:
 
 ### Example
 
@@ -257,7 +283,7 @@ A search request update is exactly the same as the search request with two diffe
 The search request update returns a search results response.
 
 ## Search Request Delete
-`HTTP DELETE` request to `<base_remote_url>/mmapi/v1/match/<queryID>`, with an `application/json` body with the following format:
+`HTTP DELETE` request to `<base_remote_url>/match/<queryID>`, with an `application/json` body with the following format:
 
 ### Example
 


### PR DESCRIPTION
This pull request is comprised of three related improvements to the basic URL and versioning of the API:
  1. The '/mmapi' prefix is unnecessary as any necessary prefix can be specified per-site as part of the base URL. 
  1. Having the API version in the URL is frowned upon, and since our uses require headers to be specified anyway (as with the auth token), it seems to make more sense to move the API version to the 'Accept' and 'Content-Type' headers. 
  1. Switching from integer to semantic versioning.

Relevant resources:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Content_negotiation
https://developer.github.com/v3/media/