### PR TITLE
Removed async and email response types

### DIFF
--- a/join-protocol.md
+++ b/join-protocol.md
@@ -8,10 +8,11 @@ It is not mandatory for **A** to automatically also accept **B**’s requests, t
 
 **1.a.** When requesting access to **B**, the administrators of **A** must send to the administrators of **B**:
 * a human readable **name** identifying **A**, to be presented to data owners on **B** when a search submitted by **A** matches patients in **B** and **B** wants to notify the data owners of a match (optional behavior that can be implemented by **B**)
-* an **authentication token** to be used by **B** in its requests to **A**, if any, to authenticate **B** to **A**, for example when sending back asynchronous match results; if the search agreement is mutual, this is also the token that **B** will use when submitting match requests to **A**
-* a **base URL** to be used for requests, including scheme (`https://`), domain, eventual port, and path prefix (trailing `/` is optional); **B** will append `/mmapi/v1/matchResults` to this path when sending back asynchronous results, or, if **B** is to also be allowed to send queries to **A**, `/mmapi/v1/match`
-* the preferred **response type** expected by **A**; if **B** does not support this type, then the two parties should negotiate what works best for them
-  * the `responseType` is defined in the search response JSON  format, with the possible values of `"inline"`|`"asynchronous"`|`"email"`
+
+**1.b.** Upon acceptance of **A** as a trusted source of queries, the administrators of **B** must respond with:
+* a suggested human readable **name** and **description** identifying **B**, to be presented to users of **A** as a possible remote site to search; **A** could ignore these and use their preferred name and description, but for consistency across systems **B**’s preference should be used
+* a **base URL** to be used for requests, including scheme (`https://`), hostname, eventual port, and path prefix (trailing `/` is optional); **A** will append `/mmapi/v1/match` to this path when sending queries
+* an **authentication token** that must be used by **A** in the search requests
 
 It is recommended to send this information in an encrypted email message, for example using PGP/GPG encryption with the recipient's public key. Plain text communication of the keys should be avoided as much as possible, and decrypted messages/keys should not be kept on personal computers.
 
@@ -29,26 +30,18 @@ gpg --decrypt --output key key.gpg
 # Now both systems have the same "key" file
 ```
 
-**1.b.** Upon acceptance of **A** as a trusted source of queries, the administrators of **B** must respond with:
-* a suggested human readable **name** and **description** identifying **B**, to be presented to users of **A** as a possible remote site to search; **A** could ignore these and use their preferred name and description, but for consistency across systems **B**’s preference should be used
-* an **authentication token** that must be used by **A** in the search requests
-* a **base URL** to be used for requests, including scheme (`https://`), hostname, eventual port, and path prefix (trailing `/` is optional); **A** will append `/mmapi/v1/match` to this path when sending queries
 
 **For data security, HTTPS is mandatory, with a valid, globally acceptable certificate!**
 
 Since authentication tokens are the only means of identifying a site, this token should be unique to each remote site accepted by **B** to correctly determine where a query comes from. There is no imposed format for the token, except that it must be less than 255 characters long. A random 40-chars SHA1 key is recommended.
 
 **2.a.** Configuring **B** to accept **A** as a trusted origin of remote searches requires that **B** stores somehow:
-* the URL prefix for HTTP requests sent to **A** (for asynchronous responses)
-* the token that **B** will send in its HTTP requests to **A**
 * the token that **B** expects in the requests from **A**
-* the response format preferred by **A**
 * the name that identifies **A**
 
 **2.b.** Configuring **A** to support **B** as a possible destination of remote searches requires that **A** stores somehow:
 * the URL prefix for HTTP requests sent to **B**
 * the token that must be sent to **B**
-* the token that **A** expects in the HTTP requests from **B**
 * the name that identifies **B**
 * the description of **B**
 

--- a/search-api.md
+++ b/search-api.md
@@ -4,18 +4,6 @@
 `HTTP POST` to remote server: `<base_remote_url>/mmapi/v1/match`
 For example: `https://yourmatchmaker.org/mmapi/v1/match`
 
-**Receive asynchronous response:**
-`HTTP POST` from remote server to: `<base_origin_url>/mmapi/v1/matchResults`
-For example: `https://mymatchmaker.org/mmapi/v1/matchResults`
-
-**Update previous request:**
-`HTTP PUT` to remote server: `<base_remote_url>/mmapi/v1/match/<queryID>`
-For example: `https://yourmatchmaker.org/mmapi/v1/match/a32fa90vd`
-
-**Delete previous request:**
-`HTTP DELETE` to remote server: `<base_remote_url>/mmapi/v1/match/<queryID>`
-For example: `https://yourmatchmaker.org/mmapi/v1/match/a32fa90vd`
-
 ## Search Request
 
 `HTTP POST` request to `<base_remote_url>/mmapi/v1/match`, with an `application/json` body with the following format:
@@ -25,7 +13,6 @@ For example: `https://yourmatchmaker.org/mmapi/v1/match/a32fa90vd`
 ```json
 {
   "id" : <identifier>,
-  "queryType" : "once"|"periodic",
 
   "label" : <identifier>,
 
@@ -79,16 +66,8 @@ For example: `https://yourmatchmaker.org/mmapi/v1/match/a32fa90vd`
 * A name/identifier assigned by the user which can be used to reference the patient in a recognizable manner (in an email for example); it should not contain any *personally identifiable information*.
 * Transparent string, limited to 255 characters in utf-8.
 
-#### Query type
-* *Optional*
-* Accepted values:
-  * `once`: only search once in the current database
-  * `periodic`: repeat the search monthly until canceled, reporting new and updated matches
-* The default value is `once`
-* If a system doesn’t support the requested type, the `once` behavior is used
-
 #### Submitter
-* ***Mandatory*** if an email response is expected, *Optional* otherwise
+* *Optional*
 * Consists of contact information of the person that submitted the search:
   * `email`: the email address where matches can be sent (***mandatory***); the values must conform to the [RFC 2822 address specification](http://tools.ietf.org/html/rfc2822#section-3.4) mailbox format (no group)
   * `name`: the first and last name (*optional*)
@@ -168,17 +147,14 @@ For example: `https://yourmatchmaker.org/mmapi/v1/match/a32fa90vd`
     * If the patch is not provided, the assembly is assumed to represent the initial (unpatched) release of that assembly.
 * This should list either *candidate genes*, using the `gene` field with optionally other more specific fields, or precise *genomic variants*, specifying the assembly, the location (`referenceName`, `start`, `end`), and the reference and alternate bases
 
-## Search Results Response
-Either a synchronous `application/json` response to a `/match` request, an asynchronous `application/json` `HTTP POST` request to `<base_origin_url>/mmapi/v1/matchResults`, or a human-readable email sent to the user’s email address.
 
-The response to the search request looks like:
+## Search Results Response
+A synchronous `application/json` response, of the following form:
 
 ### Example
 
 ```json
 {
-  "queryID" : <identifier>,
-  "responseType" : "inline"|"asynchronous"|"email",
   "results" : [
     {
       "label" : <identifier>,
@@ -195,82 +171,6 @@ The response to the search request looks like:
 }
 ```
 
-#### Query identifier
-* ***Mandatory***
-* Helps match the results to the original query for asynchronous results, and allows the submitter to manage the search submission
-* This does not have to be the same as the id sent in the request since it represents how the remote host stores queries
-* Transparent string, limited to 255 characters in utf-8.
-
-#### Response type
-* *Optional*
-* `inline` responses are sent in the same response (the default value if the results property exists)
-* `asynchronous` responses will be sent by the remote server at a later time, in a separate request to the origin server (the default value if the results property is missing)
-* `email` responses will be sent by email directly to the contact email, in a human readable format
-
 #### Results
-* *Absent* for asynchronous results
-* ***Mandatory*** for inline results, but can be empty
+* ***Mandatory***, but can be empty
 * Is a **list of matches**, where each match has the same format as the one described above for the query
-
-### Asynchronous responses
-* Are sent through a HTTPS request to the originating server
-* Same format as the synchronous response, but placed in an array and wrapped in an object, so that multiple responses can be sent at the same time
-
-```json
-{"responses":
-  [
-    {
-      "queryID" : <identifier>,
-      "results" : […]
-    },
-    {
-      "queryID" : <identifier>,
-      "results" : […]
-    },
-    …
-  ]
-}
-```
-
-### Email responses
-The format of email responses is not restricted, and is left up to each site to implement in a user-friendly way.
-
-## Search Request Update
-`HTTP PUT` request to `<base_remote_url>/mmapi/v1/match/<queryID>`, with an `application/json` body with the same format as a search request:
-
-### Example
-
-```json
-{
-  "id" : <identifier>,
-  …
-}
-```
-
-A search request update is exactly the same as the search request with two differences:
-
-* The HTTP method used is a `PUT` (as opposed to a `POST`).
-* The URL includes the `queryID` that was returned in the search result response when the search was originally submitted is required.
-* The `id` has to match the original `id` in the search request.
-* All other information in the search request is replaced with a search request update.
-
-The search request update returns a search results response.
-
-## Search Request Delete
-`HTTP DELETE` request to `<base_remote_url>/mmapi/v1/match/<queryID>`, with an `application/json` body with the following format:
-
-### Example
-
-```json
-{
-  "id" : <identifier>
-}
-```
-
-A search request delete:
-
-* The HTTP method used is a `DELETE`.
-* The URL includes the `queryID` that was returned in the search result response when the search was originally submitted is required.
-* The `id` has to match the original `id` in the search request.
-
-The search request delete returns an `OK (200)` status to indicate that the search was deleted, nothing more.


### PR DESCRIPTION
Only synchronous JSON responses are supported. This vastly simplifies the API and removes the obligation for the server to maintain any state about periodic requests (and the need for queryIds).