### PR TITLE
Replaced contact information with URL and name

### DIFF
--- a/search-api.md
+++ b/search-api.md
@@ -27,7 +27,10 @@ For example: `https://yourmatchmaker.org/mmapi/v1/match/a32fa90vd`
   "id" : <identifier>,
   "queryType" : "once"|"periodic",
 
-  "contact": <URL>,
+  "contact": {
+    "name": "Full Name",
+    "href": <URL>
+  },
   "label" : <identifier>,
   "gender" : "M"|"F",
   "ageOfOnset" : <HPO code>,
@@ -70,9 +73,11 @@ For example: `https://yourmatchmaker.org/mmapi/v1/match/a32fa90vd`
 
 #### Contact
 * ***Mandatory***
-* A public (no login required) URL for contacting the owner of the patient record to follow up with a match. This is required for both match request and match responses. This must be a valid URL (of the form `<scheme>:<address>`), and could take a number of forms:
-  * an `HTTP` URL: in this case, the URL could be a contact form which would allow the user to contact the owner of the matched patient.
-  * a `mailto` URL: in this case, the URL could be a (potentially-anonymized) email address to contact regarding the patient match.
+* The contact information describes how the eventual recipient of the match response can contact the owner of the matched patient record to follow-up on the match. It contains two components, both required:
+  1. A public (no login required) URL for contacting the owner of the patient record to follow up with a match. This must be a valid URL (of the form `<scheme>:<address>`), and could take a number of forms:
+    * an `HTTP` URL: in this case, the URL could be a contact form which would allow the user to contact the owner of the matched patient.
+    * a `mailto` URL: in this case, the URL could be a (potentially-anonymized) email address to contact regarding the patient match.
+  1. The human-readable name of the clinician or organization that the user is contacting with the provided URL. A transparent string, limited to 255 characters in utf-8.
 
 #### Label
 * *Optional*
@@ -173,7 +178,10 @@ The response to the search request looks like:
   "responseType" : "inline"|"asynchronous"|"email",
   "results" : [
     {
-      "contact": <URL>,
+      "contact": {
+        "name": "Full Name",
+        "href": <URL>
+      },
       "label" : <identifier>,
       "gender" : "M"|"F",
       "ageOfOnset" : <HPO code>,

--- a/search-api.md
+++ b/search-api.md
@@ -27,14 +27,8 @@ For example: `https://yourmatchmaker.org/mmapi/v1/match/a32fa90vd`
   "id" : <identifier>,
   "queryType" : "once"|"periodic",
 
+  "contact": <URL>,
   "label" : <identifier>,
-
-  "submitter" : {
-     "name" : "First Last",
-     "email" : <email address>,
-     "institution" : "Some Hospital"
-  },
-
   "gender" : "M"|"F",
   "ageOfOnset" : <HPO code>,
   "inheritanceMode" : <inheritance code>,
@@ -74,6 +68,12 @@ For example: `https://yourmatchmaker.org/mmapi/v1/match/a32fa90vd`
 * The internal identifier (obfuscated or not) that can be used by the originating system to reference the patient data.
 * Transparent string, limited to 255 characters in utf-8.
 
+#### Contact
+* ***Mandatory***
+* A public (no login required) URL for contacting the owner of the patient record to follow up with a match. This is required for both match request and match responses. This must be a valid URL (of the form `<scheme>:<address>`), and could take a number of forms:
+  * an `HTTP` URL: in this case, the URL could be a contact form which would allow the user to contact the owner of the matched patient.
+  * a `mailto` URL: in this case, the URL could be a (potentially-anonymized) email address to contact regarding the patient match.
+
 #### Label
 * *Optional*
 * A name/identifier assigned by the user which can be used to reference the patient in a recognizable manner (in an email for example); it should not contain any *personally identifiable information*.
@@ -86,14 +86,6 @@ For example: `https://yourmatchmaker.org/mmapi/v1/match/a32fa90vd`
   * `periodic`: repeat the search monthly until canceled, reporting new and updated matches
 * The default value is `once`
 * If a system doesn’t support the requested type, the `once` behavior is used
-
-#### Submitter
-* ***Mandatory*** if an email response is expected, *Optional* otherwise
-* Consists of contact information of the person that submitted the search:
-  * `email`: the email address where matches can be sent (***mandatory***); the values must conform to the [RFC 2822 address specification](http://tools.ietf.org/html/rfc2822#section-3.4) mailbox format (no group)
-  * `name`: the first and last name (*optional*)
-  * `institution`: human-readable institution name (*optional*)
-* **The contact information is for transmitting match results only, and may not be collected and/or used for any other purposes**
 
 #### Gender
 * *Optional*
@@ -181,8 +173,8 @@ The response to the search request looks like:
   "responseType" : "inline"|"asynchronous"|"email",
   "results" : [
     {
+      "contact": <URL>,
       "label" : <identifier>,
-      "submitter" : {…},
       "gender" : "M"|"F",
       "ageOfOnset" : <HPO code>,
       "inheritanceMode" : <inheritance code>,


### PR DESCRIPTION
As discussed in the meeting in Miami, the contact information is required for every patient object in the API, both in the match request and the match response.

Theoretically the name is either the name of a person or an institution. I'm not sure if we would want to split this into two fields, `name` and `institution`, where the later is required and the former is optional? I almost prefer it to just be a single, required, field that is human readable and not worry too much, but I'm open to ideas.