### PR TITLE
Require API version in request header

### DIFF
--- a/search-api.md
+++ b/search-api.md
@@ -9,13 +9,13 @@ For example: `https://yourmatchmaker.org/match`
 
 A particular API version can be specified using the HTTP `Accept` header.
 
-`Accept: application/vnd.ga4gh.matchmaker[.version]+json`
+`Accept: application/vnd.ga4gh.matchmaker.<version>+json`
 
-Where version takes the form `vX.Y`. For example:
+Where `<version>` takes the form `vX.Y`. For example:
 
 `Accept: application/vnd.ga4gh.matchmaker.v0.1+json`
 
-If no version is specified, the remote server should respond in the latest version supported by the remote server. The remote server should always provide the API version in the `Content-Type` header of every response:
+The remote server should always provide the API version in the `Content-Type` header of every response:
 
 `Content-Type: application/vnd.ga4gh.matchmaker.v0.7+json`
 

--- a/search-api.md
+++ b/search-api.md
@@ -7,7 +7,7 @@ For example: `https://yourmatchmaker.org/match`
 
 ## Versioning
 
-A particular API version can be specified using the HTTP `Accept` header.
+Every request must specify the API version within the HTTP `Accept` header.
 
 `Accept: application/vnd.ga4gh.matchmaker.<version>+json`
 
@@ -15,7 +15,7 @@ Where `<version>` takes the form `vX.Y`. For example:
 
 `Accept: application/vnd.ga4gh.matchmaker.v0.1+json`
 
-The remote server should always provide the API version in the `Content-Type` header of every response:
+The remote server must provide the API version of the response in the `Content-Type` header of every response:
 
 `Content-Type: application/vnd.ga4gh.matchmaker.v0.7+json`
 


### PR DESCRIPTION
Made API version required in the Accept header, and removed mention of a "default" version.