### PR TITLE
Renamed 'features' and 'contact' fields

### DIFF
--- a/search-api.md
+++ b/search-api.md
@@ -42,7 +42,7 @@ After receiving a request, the remote server can respond in one of two ways:
     "id" : <identifier>,
     "label" : <identifier>,
 
-    "contact" : {
+    "submitter" : {
       "name" : "Full Name",
       "institution" : "Contact Institution",
       "href" : <URL>
@@ -59,7 +59,7 @@ After receiving a request, the remote server can respond in one of two ways:
       },
       …
     ],
-    "features" : [
+    "phenotypes" : [
       {
         "id" : <HPO code>,
         "observed" : "yes"|"no"|"unknown",
@@ -100,7 +100,7 @@ After receiving a request, the remote server can respond in one of two ways:
 * A name/identifier assigned by the user which can be used to reference the patient in a recognizable manner (in an email for example); it should not contain any *personally identifiable information*.
 * Transparent string, limited to 255 characters in utf-8.
 
-#### Contact
+#### Submitter
 * ***Mandatory***
 * The contact information describes how the eventual recipient of the match response can contact the owner of the matched patient record to follow-up on the match.
   1. `name` : The human-readable name of the clinician or organization that the user is contacting with the provided URL. A transparent string, limited to 255 characters in utf-8. (***Mandatory***)
@@ -173,17 +173,17 @@ After receiving a request, the remote server can respond in one of two ways:
 * Is a list of [OMIM](http://omim.org/) (`MIM:######`) or [OrphaNet](http://www.orphadata.org/) (`Orphanet:#####`, where the fragment is either numeric or `C####`) identifiers, can be empty
 * NOTE: we may want to support other sources later.
 
-#### Features
-* It is ***mandatory*** to have at least one of these three: `features`, `genes`, `variants` (having all is preferred)
-* Is a **list of features** described by:
+#### Phenotypes
+* It is ***mandatory*** to have at least one of these three: `phenotypes`, `genes`, `variants` (having all is preferred)
+* Is a **list of phenotypes** described by:
   * `id`: an  HPO term identifier of the form: `HP:#######`
   * `observed`: `"yes"`|`"no"`|`"unknown"`
   * `ageOfOnset`: same as the global age of onset described above (*optional*; system which do not support this type of information per symptom should ignore it)
-* More metadata can be later added to each feature if necessary.
-* By default we shouldn’t sent any features with the `observed` status (or value) `"unknown"`
+* More metadata can be later added to each phenotype if necessary.
+* By default we shouldn’t sent any phenotypes with the `observed` status (or value) `"unknown"`
 
 #### Genes
-* It is ***mandatory*** to have at least one of these three: `features`, `genes`, `variants` (having all is preferred)
+* It is ***mandatory*** to have at least one of these three: `phenotypes`, `genes`, `variants` (having all is preferred)
 * Is a **list of candidate causal genes** described by:
   * `gene`:
     * `<gene symbol>` from the [HGNC database](http://www.genenames.org/) OR
@@ -191,7 +191,7 @@ After receiving a request, the remote server can respond in one of two ways:
     * `<entrez gene ID>`
 
 #### Variants
-* It is ***mandatory*** to have at least one of these three: `features`, `genes`, `variants` (having all is preferred)
+* It is ***mandatory*** to have at least one of these three: `phenotypes`, `genes`, `variants` (having all is preferred)
 * Is a **list of candidate genomic variants** described by:
   * `assembly`: reference assembly identifier, including patch number if relevant, of the form: `<assembly>[.<patch>]` (***mandatory***)
     * example valid values: `"NCBI36"`, `"GRCh37"`, `"GRCh37.p13"`, `"GRCh38"`, `"GRCh38.p1"`


### PR DESCRIPTION
After discussing our API with the GA4GH Metadata Task Team, they had a few suggestions. Among them were renaming 'features' to 'phenotypes', and 'contact' to something less ambiguous (I thought 'submitter' was better).