### PR TITLE
Issue #62: Make start position mandatory for variants

### DIFF
--- a/search-api.md
+++ b/search-api.md
@@ -191,7 +191,7 @@ After receiving a request, the remote server can respond in one of two ways:
     * example valid values: `"NCBI36"`, `"GRCh37"`, `"GRCh37.p13"`, `"GRCh38"`, `"GRCh38.p1"`
     * If the patch is not provided, the assembly is assumed to represent the initial (unpatched) release of that assembly.
   * `referenceName`: `"1"`, `"2"`, …, `"22"`, `"X"`, `"Y"`; the chromosome this variant or gene is on (***mandatory***)
-  * `start`: `<number>`; the start position of the variant. (0-based) (*optional*)
+  * `start`: `<number>`; the start position of the variant. (0-based) (***mandatory***)
   * `end`: `<number>`; the end position of the variant. (0-based, exclusive) (*optional*)
   * `referenceBases`: `"A"`|`"ACG"`|…, VCF-style reference of at least one base (*optional*)
   * `alternateBases`: `"A"`|`"ACG"`|…, VCF-style alternate allele of at least one base (*optional*)


### PR DESCRIPTION
Start position of a variant now mandatory, as genes are now in their own object.
https://github.com/MatchMakerExchange/mme-apis/issues/62