### PR TITLE
Issue #34: added mandatory score to each response patient

### DIFF
--- a/search-api.md
+++ b/search-api.md
@@ -206,6 +206,9 @@ A synchronous `application/json` response, of the following form:
 {
   "results" : [
     {
+	  "score" : {
+        "patient" : <number>
+      }
       "patient" : {…},
     },
     …
@@ -214,9 +217,17 @@ A synchronous `application/json` response, of the following form:
 ```
 
 #### Results
-* ***Mandatory***, but can be empty
-* Is a **list of matches**, where each match has a `patient` object of the same format as the one described above for the query
+* ***Mandatory***, but can be empty.
+* Is a **list of matches**, where each match has a `patient` object, and a `score` object with information about how well the `patient` object matched.
 
+##### Score
+* ***Mandatory***
+* Information about how well this results patient matched the query patient.
+* Currently, this has a single ***mandatory*** field, `patient`, with a numerical value corresponding to the overall score of the match. This score must be in the range [0, 1], where 0.0 is a poor match and 1.0 is a perfect match.
+
+##### Patient
+* ***Mandatory***
+* A `patient` object of the same form as the one described above for the query.
 
 ### Error handling
 The remote server should use HTTP status codes to report any errors encoundered processing the match request. Here are a list of status codes and their meanings with regards to this API:


### PR DESCRIPTION
Not sure if this implementation is to everyone's satisfaction, but this allows the query and response `patient`s to remain the same, and allows arbitrary extension to add more detailed scoring.

For example, for v1.1, we could add `"features"` or `"genes"` or `"variants"` fields within the `score` object, each able to represent the matching scores of individual terms that were used for matching. This would be in contrast to adding something like a `"weight"` to each gene, feature, and variant for use in both the query and the response objects, related to the relative weight of each of those for use in matchmaking.